### PR TITLE
ISLANDORA-2048: Add PIDs to list of Simple Workflow objects

### DIFF
--- a/includes/manage.inc
+++ b/includes/manage.inc
@@ -42,8 +42,9 @@ function islandora_simple_workflow_manage_form($form, $form_state) {
     $rows = array();
     foreach ($inactive_objects as $inactive_object) {
       $pid = $inactive_object['object']['value'];
-      $rows[$pid] = array(l($inactive_object['title']['value'], "islandora/object/$pid"));
+      $rows[$pid] = array(l($inactive_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
     }
+    ksort($rows);
     $form['management_table'] = array(
       '#type' => 'tableselect',
       '#header' => array(t('Object')),

--- a/includes/manage.inc
+++ b/includes/manage.inc
@@ -44,7 +44,6 @@ function islandora_simple_workflow_manage_form($form, $form_state) {
       $pid = $inactive_object['object']['value'];
       $rows[$pid] = array(l($inactive_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
     }
-    ksort($rows);
     $form['management_table'] = array(
       '#type' => 'tableselect',
       '#header' => array(t('Object')),


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2048)

# What does this Pull Request do?

Adds the object PID in parentheses next to object label, to make it easier to identify them and which namespace they belong to.

# What's new?

Adds the $pid variable in parentheses to the $row that displays the object. No other changes.

# How should this be tested?

- Make several objects inactive
- View the list of Simple Workflow objects
- Verify that PID displays as expected next to object label

# Interested parties
@DiegoPino, @Islandora/7-x-1-x-committers
