### PR TITLE
Check access with object as context.

### DIFF
--- a/islandora_simple_workflow.module
+++ b/islandora_simple_workflow.module
@@ -51,7 +51,7 @@ function islandora_simple_workflow_islandora_object_alter(AbstractObject $object
         $system_objects[] = $solution_pack_object->id;
       }
     }
-    if (!in_array($object->id, $system_objects) && !user_access('bypass inactive object state')) {
+    if (!in_array($object->id, $system_objects) && !islandora_object_access('bypass inactive object state', $object)) {
       $object->state = 'I';
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2064](https://jira.duraspace.org/browse/ISLANDORA-2064)

# What does this Pull Request do?

Add more context to access check, permitting overrides.

# What's new?

* Use `islandora_object_access()` instead of `user_access()` for access control to allow things to be influenced from our access hooks.

# How should this be tested?

Primarily, regression testing: Things should work as they did.

Simple test module exposing a block allowing the permissions to be denied via our hooks: https://github.com/adam-vessey/islandora_2064_test

# Additional Notes:

* **Does this change require documentation to be updated?** No.
* **Does this change add any new dependencies?** No.
* **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
* **Could this change impact execution of existing code?** Unlikely, but it _is_ possible.

# Interested parties

@jordandukart (as component manager), @DiegoPino (since this is bubbling out of other PRs), @Islandora/7-x-1-x-committers

---

The search:
```
islandora_simple_workflow @ 878d514edda5b5b3da0c1a155ddf1e39858e8832
/var/www/drupal7/sites/all/modules/islandora_simple_workflow$ git grep -n user_access
# Can do, but... is somewhat different, being in the ingest phase (dealing
# with an object which does not yet exist in the repo).
islandora_simple_workflow.module:54:    if (!in_array($object->id, $system_objects) && !user_access('bypass inactive object state')) {
```