### PR TITLE
ISLANDORA-2218: Add parent column for inactive object management table

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Admin form.
+ */
+
+/**
+ * Admin settings form for Islandora Simple Workflow configuration.
+ *
+ * @param array $form
+ *   An array representing a form within Drupal.
+ * @param array $form_state
+ *   An array containing the Drupal form state.
+ */
+function islandora_simple_workflow_admin_form(array $form, array &$form_state) {
+  $form['islandora_simple_workflow_toggle_parent_column'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show Parent column in Inactive Object table'),
+    '#default_value' => variable_get('islandora_simple_workflow_toggle_parent_column', FALSE),
+    '#description' => t('Enabling this will provide helpful links back to the parent object, but could incur a performance hit in repositories with many inactive objects.'),
+  );
+
+  return system_settings_form($form);
+}

--- a/includes/manage.inc
+++ b/includes/manage.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Management form for the Islandora Simple Workflow module.
@@ -17,6 +18,7 @@
  */
 function islandora_simple_workflow_manage_form($form, $form_state) {
   module_load_include('inc', 'islandora_simple_workflow', 'includes/utilities');
+  module_load_include('inc', 'islandora', 'includes/utilities');
 
   if (isset($form_state['show_confirm'])) {
     $form['confirm_message'] = array(
@@ -38,15 +40,42 @@ function islandora_simple_workflow_manage_form($form, $form_state) {
     );
   }
   else {
+    $render_parents = variable_get('islandora_simple_workflow_toggle_parent_column', FALSE);
     $inactive_objects = islandora_simple_workflow_get_inactive_objects();
+
     $rows = array();
+
     foreach ($inactive_objects as $inactive_object) {
-      $pid = $inactive_object['object']['value'];
-      $rows[$pid] = array(l($inactive_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
+      $object_pid = $inactive_object['object']['value'];
+      $rows[$object_pid][] = l($inactive_object['title']['value'] . " (" . $object_pid . ")", "islandora/object/$object_pid");
+
+      if ($render_parents) {
+        $object = islandora_object_load($object_pid);
+
+        if ($object) {
+          $parents = islandora_get_parents_from_rels_ext($object);
+          $inactive_object['parents'] = array();
+
+          foreach ($parents as $parent) {
+            $inactive_object['parents'][] = l($parent->id, "islandora/object/$parent->id");
+          }
+
+          $rows[$object_pid][] = implode(', ', $inactive_object['parents']);
+        }
+      }
     }
+
+    $header = array(
+      t('Object'),
+    );
+
+    if ($render_parents) {
+      $header[] = t('Parents');
+    }
+
     $form['management_table'] = array(
       '#type' => 'tableselect',
-      '#header' => array(t('Object')),
+      '#header' => $header,
       '#options' => $rows,
       '#attributes' => array(),
       '#empty' => t('No inactive objects were found.'),

--- a/islandora_simple_workflow.info
+++ b/islandora_simple_workflow.info
@@ -2,5 +2,6 @@ name = Islandora Simple Workflow
 description = A simple editorial workflow for Islandora. Ingested objects are inactive until approved.
 dependencies[] = islandora
 package = Islandora Tools
+configure = admin/islandora/tools/simple_workflow/settings
 version = 7.x-dev
 core = 7.x

--- a/islandora_simple_workflow.install
+++ b/islandora_simple_workflow.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Install hooks for this module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function islandora_simple_workflow_uninstall() {
+  variable_del('islandora_simple_workflow_toggle_parent_column');
+}

--- a/islandora_simple_workflow.module
+++ b/islandora_simple_workflow.module
@@ -9,16 +9,36 @@
  * Implements hook_menu().
  */
 function islandora_simple_workflow_menu() {
-  $items = array();
-  $items['admin/islandora/tools/simple_workflow/list'] = array(
-    'title' => 'Simple Workflow objects',
-    'description' => 'List of inactive objects.',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('islandora_simple_workflow_manage_form'),
-    'access arguments' => array('manage inactive objects'),
-    'file' => 'includes/manage.inc',
+  return array(
+    'admin/islandora/tools/simple_workflow' => array(
+      'title' => 'Simple Workflow inactive objects',
+      'type' => MENU_NORMAL_ITEM,
+      'description' => 'List of inactive objects.',
+      'access arguments' => array('manage inactive objects'),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_simple_workflow_manage_form'),
+      'file' => 'includes/manage.inc',
+    ),
+    'admin/islandora/tools/simple_workflow/list' => array(
+      'title' => 'Simple Workflow inactive objects',
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+      'weight' => -10,
+      'description' => 'List of inactive objects.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_simple_workflow_manage_form'),
+      'access arguments' => array('manage inactive objects'),
+      'file' => 'includes/manage.inc',
+    ),
+    'admin/islandora/tools/simple_workflow/settings' => array(
+      'title' => 'Simple Workflow settings',
+      'type' => MENU_LOCAL_TASK,
+      'description' => 'Configuration settings for Islandora Simple Workflow module.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_simple_workflow_admin_form'),
+      'access arguments' => array('administer site configuration'),
+      'file' => 'includes/admin.inc',
+    ),
   );
-  return $items;
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2218

# What does this Pull Request do?

Add a new configuration option to toggle a 'Parents' column for the Inactive object management list. This new addition should provide helpful links to the parent object(s) for each inactive object.

# What's new?

* Added admin configuration form file admin.inc
* Added islandora_simple_workflow.install to remove configuration variable on module uninstall
* Added menu path 'admin/islandora/tools/simple_workflow/settings', included configuration path in islandora_simple_workflow.info

# How should this be tested?

* Ingest a few different Objects using a variety of cModels (book, large image, pdf, etc.)
* Ensure that each Object's status is set to 'inactive' (may want disable the 'bypass inactive object state' permission to avoid this step)
* In the simple workflow module's settings page enable the parent column.
* Ensure that each inactive object has their parent column information showing up properly (this should include Objects with multiple parents).

Now pick a handful of Objects and set Object viewing XACML restrictions on their parent Object(s) for your test user:
* Refresh the inactive object list and ensure that the parent Objects that you no longer have access to don't show up under the column.

# Interested parties
I can't seem to ping the committers group, so I'll just ping @jordandukart :-)